### PR TITLE
Changed many URIs to protocol relative URIs

### DIFF
--- a/cc/licenserdf/rdf/ns.html
+++ b/cc/licenserdf/rdf/ns.html
@@ -18,13 +18,13 @@
     <base href="http://creativecommons.org/ns" />
 
     <link rel="stylesheet" type="text/css" 
-	  href="http://creativecommons.org/wp-content/themes/cc4/style.css" />
+	  href="//creativecommons.org/wp-content/themes/cc4/style.css" />
     <link rel="stylesheet" type="text/css" 
-	  href="http://creativecommons.org/wp-content/themes/cc4/support.css" />
+	  href="//creativecommons.org/wp-content/themes/cc4/support.css" />
     <link rel="stylesheet" type="text/css" 
-	  href="http://creativecommons.org/includes/ns.css"/>
+	  href="//creativecommons.org/includes/ns.css"/>
 
-    <!--[if IE]><link rel="stylesheet" type="text/css" media="screen" href="http://creativecommons.org/wp-content/themes/cc4/style-ie.css" />
+    <!--[if IE]><link rel="stylesheet" type="text/css" media="screen" href="//creativecommons.org/wp-content/themes/cc4/style-ie.css" />
     <![endif]-->
 
   </head>
@@ -54,9 +54,9 @@
 		  REL) lets you describe copyright licenses in RDF.
 		  For more information on describing licenses in RDF
 		  and attaching those descriptions to digital works,
-		  see <a href="http://wiki.creativecommons.org/CC_REL">CC
+		  see <a href="//wiki.creativecommons.org/CC_REL">CC
 		  REL</a> in
-		  the <a href="http://wiki.creativecommons.org/">Creative
+		  the <a href="//wiki.creativecommons.org/">Creative
 		  Commons wiki</a>.
 		</p>
 
@@ -281,7 +281,7 @@
 		<div id="legalcode" about="#legalcode" 
 		     typeof="rdf:Property">
 		  <h4>cc:legalcode</h4> The <a rel="rdfs:range"
-		  href="http://www.w3.org/2000/01/rdf-schema#Resource">
+		  href="//www.w3.org/2000/01/rdf-schema#Resource">
 		  URL</a> of the legal text of a <a rel="rdfs:domain"
 		  href="#License">License</a>.
 		</div>
@@ -291,7 +291,7 @@
 		  <h4>cc:deprecatedOn</h4> A <a rel="rdfs:domain"
 		  href="#License">License</a> may be deprecated;
 		  provides the <a rel="rdfs:range"
-		  href="http://www.w3.org/2001/XMLSchema-datatypes#date">date</a> <span property="rdfs:label">deprecated
+		  href="//www.w3.org/2001/XMLSchema-datatypes#date">date</a> <span property="rdfs:label">deprecated
 		  on</span>.
 		</div>
 
@@ -305,9 +305,9 @@
 		  license</span> a <a rel="rdfs:range"
 		  href="#License">License</a>. <br />
 		  (a <a rel="rdfs:subPropertyOf"
-		  href="http://purl.org/dc/terms/license">subproperty
+		  href="//purl.org/dc/terms/license">subproperty
 		  of dc:license</a>, <a rel="owl:sameAs"
-		  href="http://www.w3.org/1999/xhtml/vocab#license">the
+		  href="//www.w3.org/1999/xhtml/vocab#license">the
 		  same as xhtml:license</a>)
 		  <span rev="owl:equivalentProperty"
 			resource="http://web.resource.org/cc/license"></span>
@@ -339,7 +339,7 @@
 		<div id="attributionURL" about="#attributionURL" 
 		     typeof="rdf:Property">
 		  <h4>cc:attributionURL</h4> The <a rel="rdfs:range"
-		  href="http://www.w3.org/2000/01/rdf-schema#Resource">
+		  href="//www.w3.org/2000/01/rdf-schema#Resource">
 		  URL</a> the creator of a <a rel="rdfs:domain"
 		  href="#Work">Work</a> would like used when
 		  attributing re-use.
@@ -377,24 +377,24 @@
     <div id="footer">
       <div id="sub-footer" class="box">
         <ul>
-          <li><a href="http://wiki.creativecommons.org/Developers">Developers</a></li>
+          <li><a href="//wiki.creativecommons.org/Developers">Developers</a></li>
         </ul>
 
       </div>
       <div><p class="box">
-	  <a rel="license" href="http://creativecommons.org/licenses/by/3.0/">
-	    <img src="http://i.creativecommons.org/l/by/3.0/88x31.png" alt="Creative Commons License" style="border: medium none ;" height="31" width="88" />
+	  <a rel="license" href="//creativecommons.org/licenses/by/3.0/">
+	    <img src="//i.creativecommons.org/l/by/3.0/88x31.png" alt="Creative Commons License" style="border: medium none ;" height="31" width="88" />
 	  </a>
 	  Except where otherwise <a class="subfoot"
 href="/policies#license">noted</a>, content on this site is licensed
 under a <a rel="license"
-href="http://creativecommons.org/licenses/by/3.0/"
+href="//creativecommons.org/licenses/by/3.0/"
 class="subfoot">Creative Commons Attribution 3.0 License</a>
       </p></div>
 
     </div>
 
-    <script src="http://www.google-analytics.com/urchin.js" type="text/javascript"></script>
+    <script src="//www.google-analytics.com/urchin.js" type="text/javascript"></script>
     <script type="text/javascript">_uacct = "UA-2010376-1"; urchinTracker();</script>
   </body>
 


### PR DESCRIPTION
The page would not load properly on my browser (which enforces HTTPS
using https://www.eff.org/https-everywhere).

With these changes many of the URIs now follow the protocol that was
used when accessing the page.

I only changed the URIs for href in ‘a’ and ‘link’.

I did not change the URIs in <span resource=“”> As I am unsure wether
the URI standard allows that and if it is a desired output.
